### PR TITLE
feat: create skeleton API for inject package

### DIFF
--- a/inject/lifetime.go
+++ b/inject/lifetime.go
@@ -1,0 +1,27 @@
+package inject
+
+// A ServiceLifetime describes the instantiation semantics for a service provided by a
+// [ServiceProvider].
+type ServiceLifetime int
+
+const (
+	// A Transient service has a new instance created every time the service is resolved.
+	Transient ServiceLifetime = iota
+
+	// A Scoped service has a single instance created per [ServiceProvider]. If the same service is
+	// resolved multiple times from the same [ServiceProvider] then the same instance will be
+	// returned. If a new [ServiceProvider] scope is created and the same service is resolved from
+	// the new [ServiceProvider] then a single new instance will be created and returned every time
+	// the service is resolved from the new [ServiceProvider].
+	//
+	// NOTE: That because of the need to return the same instance multiple times, Scoped services
+	// can only be registered for interfaces and pointer types.
+	Scoped
+
+	// A Singleton service has a single instance created and returned every time the service is
+	// resolved from a top level [ServiceProvider] or any its descendant scopes.
+	//
+	// NOTE: That because of the need to return the same instance multiple times, Singleton
+	// services can only be registered for interfaces and pointer types.
+	Singleton
+)

--- a/inject/resolve.go
+++ b/inject/resolve.go
@@ -1,0 +1,44 @@
+package inject
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// A ServiceResolver resolves instances of a requested type.
+type ServiceResolver interface {
+
+	// Resolve provides an instance of the requested type if one is registered. Implementations
+	// MUST ensure that the values returned are assignable to the requested type.
+	Resolve(reflect.Type) (any, error)
+}
+
+// Resolve obtains an instance of the requested type from a [ServiceResolver]. An error is returned
+// when the [ServiceResolver] returns an error and when the value returned by the [ServiceResolver]
+// is not assignable to T.
+func Resolve[T any](resolver ServiceResolver) (T, error) {
+	var defaultT T
+	// If we just take the TypeOf defaultT directly we'll get nil for interface types but if we
+	// get the element (pointed to) type of a pointer to T we'll get T the actual T.
+	type_ := reflect.TypeOf(&defaultT).Elem()
+	resolved, err := resolver.Resolve(type_)
+	if err != nil {
+		return defaultT, err
+	}
+	typed, ok := resolved.(T)
+	if !ok {
+		return typed, fmt.Errorf("ServiceResolver returned %T when %T was requested", resolved, defaultT)
+	}
+	return typed, nil
+}
+
+// MustResolve obtains an intance of the requested type from a [ServiceResolver] and panics when
+// the [ServiceResolver] returns an error and when the value returned by the [ServiceResolver] is
+// not assignable to T.
+func MustResolve[T any](resolver ServiceResolver) T {
+	service, err := Resolve[T](resolver)
+	if err != nil {
+		panic(err)
+	}
+	return service
+}

--- a/inject/resolve_test.go
+++ b/inject/resolve_test.go
@@ -1,0 +1,89 @@
+package inject
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestResolve(t *testing.T) {
+
+	t.Run("requests the type of T from the ServiceResolver", func(t *testing.T) {
+		var asFooer fooer
+		// If we just take the TypeOf defaultT directly we'll get nil for interface types but if we
+		// get the element (pointed to) type of a pointer to T we'll get T the actual T.
+		expected := reflect.TypeOf(&asFooer).Elem()
+		sp := mockResolver{}
+		sp.returns(&assignableToFooer{}, nil)
+		_, _ = Resolve[fooer](&sp)
+		if sp.requestedTypes[0] != expected {
+			t.Fatalf("expected %v; got %v", expected, sp.requestedTypes[0])
+		}
+	})
+
+	t.Run("returns errors from the ServiceResolver", func(t *testing.T) {
+		expectedErr := errors.New("expected error")
+		sp := mockResolver{}
+		sp.returns(0, expectedErr)
+		if _, actualErr := Resolve[int](&sp); !errors.Is(actualErr, expectedErr) {
+			t.Fatalf("expected %v; got %v", expectedErr, actualErr)
+		}
+	})
+
+	t.Run("returns error when the returned value is not assignable to requested to type", func(t *testing.T) {
+		sp := mockResolver{}
+		sp.returns(0, nil)
+		if _, err := Resolve[string](&sp); err == nil {
+			t.Fatal("expected error; got <nil>")
+		}
+	})
+
+	t.Run("returns resolved value when assignable to requested type", func(t *testing.T) {
+		expected := &assignableToFooer{}
+		sp := mockResolver{}
+		sp.returns(expected, nil)
+		actual, err := Resolve[fooer](&sp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if actual != expected {
+			t.Fatalf("expected %v; got %v", expected, actual)
+		}
+	})
+}
+
+type fooer interface {
+	Foo()
+}
+
+type assignableToFooer struct{}
+
+func (assignableToFooer) Foo() {}
+
+type mockResolver struct {
+	returnValues []struct {
+		v   any
+		err error
+	}
+	requestedTypes []reflect.Type
+}
+
+func (m *mockResolver) returns(v any, err error) {
+	m.returnValues = append(m.returnValues, struct {
+		v   any
+		err error
+	}{
+		v:   v,
+		err: err,
+	})
+}
+
+func (m *mockResolver) Resolve(type_ reflect.Type) (any, error) {
+	m.requestedTypes = append(m.requestedTypes, type_)
+	if len(m.returnValues) == 0 {
+		panic("no return values configured")
+	}
+	r := m.returnValues[0]
+	m.returnValues = m.returnValues[1:]
+	return r.v, r.err
+}

--- a/inject/servicecollection.go
+++ b/inject/servicecollection.go
@@ -1,0 +1,96 @@
+package inject
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+)
+
+// A ServiceCollection is a collection into which services can be registered and from which a
+// [ServiceProvider] may be built.
+type ServiceCollection struct {
+	registrations map[reflect.Type]serviceRegistration
+}
+
+type serviceRegistration struct {
+	lifetime ServiceLifetime
+	factory  func() (any, error)
+}
+
+// Build creates a [ServiceProvider] from the target [ServiceCollection]. A non-nil error is
+// returned when the [ServiceCollection] is determined to be in a bad state at the time of the
+// call, e.g. if a registered service has a dependency on a service type for which no
+// implementation is registered, or if there are circular dependencies.
+func (collection *ServiceCollection) Build() (ServiceProvider, error) {
+	provider := ServiceProvider{
+		registrations: make(map[reflect.Type]serviceRegistration),
+	}
+	maps.Copy(provider.registrations, collection.registrations)
+	return provider, nil
+}
+
+// RegisterType registers the type of the given T as the concrete type to satisfy the service type
+// T when instances are resolved from a [ServiceProvider] built from the given [ServiceCollection].
+// After the instance is resolved, every exported field will be initialized by the same
+// [ServiceProvider]. Note that the given instance of T is not used directly even for types
+// registered with Singleton lifetime.
+func RegisterType[T any](collection *ServiceCollection, lifetime ServiceLifetime, type_ T) {
+	if lifetime != Transient {
+		panic("unimplemented")
+	}
+
+	if collection.registrations == nil {
+		collection.registrations = make(map[reflect.Type]serviceRegistration)
+	}
+	collection.registrations[TypeOf[T]()] = serviceRegistration{
+		lifetime: lifetime,
+		factory: func() (any, error) {
+			var t T
+			return t, nil
+		},
+	}
+}
+
+// RegisterFunc registers the given function as the factory to satisfy the service type T when
+// instances are resolved from a [ServiceProvider] built from the given [ServiceCollection].
+// Instances resolved by functions will not have their exported fields populated automatically so
+// the function must handle all required service initialization. The function will receive the same
+// [ServiceResolver] from which the instance is being resolved and may use it to initialize the
+// service.
+func RegisterFunc[T any](
+	collection *ServiceCollection,
+	lifetime ServiceLifetime,
+	fn func(*ServiceResolver) T,
+) {
+	// NOTE: We can validate cyclic dependencies in RegisterType at build time but we can't find
+	// them here without running the funcs. Consider executing them with a ServiceResolver impl
+	// that tracks the resolutions to find cycles.
+	panic("unimplemented")
+}
+
+// A ServiceProvider is a factory from which services can be resolved by type.
+type ServiceProvider struct {
+	registrations map[reflect.Type]serviceRegistration
+}
+
+var _ ServiceResolver = &ServiceProvider{}
+
+// NewScope creates a new ServiceProvider which will create distinct instances when resolving any
+// [Scoped] services.
+func (s *ServiceProvider) NewScope() ServiceProvider {
+	panic("unimplemented")
+}
+
+// Resolve provides an instance of the requested type if one is registered.
+func (provider *ServiceProvider) Resolve(type_ reflect.Type) (any, error) {
+	registration, ok := provider.registrations[type_]
+	if !ok {
+		return nil, fmt.Errorf("no implementation registered for service type %v", type_)
+	}
+	switch registration.lifetime {
+	case Transient:
+		return registration.factory()
+	default:
+		panic("unimplemented")
+	}
+}

--- a/inject/servicecollection_test.go
+++ b/inject/servicecollection_test.go
@@ -1,0 +1,33 @@
+package inject
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRegisterType(t *testing.T) {
+	// The effect of registering a type is observed through its resolution so the tests here will
+	// tend to involve setting up one or more registrations, building a service provider, then
+	// resolving the target service to ensure correctness.
+
+	t.Run("register transient struct", func(t *testing.T) {
+		sc := ServiceCollection{}
+		RegisterType(&sc, Transient, structWithNoExportedFields{})
+		sp, err := sc.Build()
+		if err != nil {
+			t.Fatalf("unexpected error building ServiceProvider: %v", err)
+		}
+		resolved, err := sp.Resolve(TypeOf[structWithNoExportedFields]())
+		if err != nil {
+			t.Fatalf("unexpected error resolving service: %v", err)
+		}
+		if _, ok := resolved.(structWithNoExportedFields); !ok {
+			t.Fatalf(
+				"resolved service has unexpected type: want %v; got %v",
+				TypeOf[structWithNoExportedFields](),
+				reflect.TypeOf(resolved))
+		}
+	})
+}
+
+type structWithNoExportedFields struct{}

--- a/inject/typeof.go
+++ b/inject/typeof.go
@@ -1,0 +1,15 @@
+package inject
+
+import (
+	"reflect"
+)
+
+// TypeOf returns the [reflect.Type] of T.
+//
+// The [reflect.TypeOf] function returns the [reflect.Type] of the VALUE given rather than the type
+// of the expresion. For example, if a variable of an interface type holds nil and that variable is
+// passed to [reflect.TypeOf] then the returned [reflect.Type] will be nil, the type of the value,
+// instead of the interface type, the type of the expression.
+func TypeOf[T any]() reflect.Type {
+	return reflect.TypeOf(new(T)).Elem()
+}

--- a/inject/typeof_test.go
+++ b/inject/typeof_test.go
@@ -1,0 +1,123 @@
+package inject
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTypeOf(t *testing.T) {
+
+	testCases := []struct {
+		testName    string
+		expected    reflect.Type
+		notExpected []reflect.Type
+		actual      reflect.Type
+	}{
+		{
+			testName: "int",
+			expected: reflect.TypeOf(int(42)),
+			actual:   TypeOf[int](),
+		},
+		{
+			testName: "int alias",
+			expected: reflect.TypeOf(intAlias(int(42))),
+			notExpected: []reflect.Type{
+				reflect.TypeOf(int(42)),
+			},
+			actual: TypeOf[intAlias](),
+		},
+		{
+			testName: "pointer to int",
+			expected: reflect.TypeOf(new(int)),
+			actual:   TypeOf[*int](),
+		},
+		{
+			testName: "pointer to in aliast",
+			expected: reflect.TypeOf(new(intAlias)),
+			notExpected: []reflect.Type{
+				reflect.TypeOf(new(int)),
+			},
+			actual: TypeOf[*intAlias](),
+		},
+		{
+			testName: "empty struct",
+			expected: reflect.TypeOf(struct{}{}),
+			actual:   TypeOf[struct{}](),
+		},
+		{
+			testName: "struct alias",
+			expected: reflect.TypeOf(emptyStructAlias{}),
+			notExpected: []reflect.Type{
+				reflect.TypeOf(struct{}{}),
+			},
+			actual: TypeOf[emptyStructAlias](),
+		},
+		{
+			testName: "pointer to struct",
+			expected: reflect.TypeOf(new(struct{})),
+			actual:   TypeOf[*struct{}](),
+		},
+		{
+			testName: "pointer to struct alias",
+			expected: reflect.TypeOf(new(emptyStructAlias)),
+			notExpected: []reflect.Type{
+				reflect.TypeOf(new(struct{})),
+			},
+			actual: TypeOf[*emptyStructAlias](),
+		},
+		{
+			testName: "interface",
+			expected: reflect.TypeOf(new(interface{})).Elem(),
+			notExpected: []reflect.Type{
+				func() reflect.Type {
+					var x interface{}
+					return reflect.TypeOf(x)
+				}(),
+			},
+			actual: TypeOf[interface{}](),
+		},
+		{
+			testName: "interface alias",
+			expected: reflect.TypeOf(new(emptyInterfaceAlias)).Elem(),
+			notExpected: []reflect.Type{
+				func() reflect.Type {
+					var x emptyInterfaceAlias
+					return reflect.TypeOf(x)
+				}(),
+			},
+			actual: TypeOf[emptyInterfaceAlias](),
+		},
+		{
+			testName: "pointer to interface",
+			expected: reflect.TypeOf(new(interface{})),
+			actual:   TypeOf[*interface{}](),
+		},
+		{
+			testName: "pointer to interface alias",
+			expected: reflect.TypeOf(new(emptyInterfaceAlias)),
+			notExpected: []reflect.Type{
+				reflect.TypeOf(new(interface{})),
+			},
+			actual: TypeOf[*emptyInterfaceAlias](),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			if tt.actual != tt.expected {
+				t.Fatalf("expected %v; got %v", tt.expected, tt.actual)
+			}
+			for _, notExpected := range tt.notExpected {
+				if tt.actual == notExpected {
+					t.Fatalf("got unexpected value %v", notExpected)
+				}
+			}
+		})
+	}
+}
+
+type intAlias int
+
+type emptyStructAlias struct{}
+
+type emptyInterfaceAlias interface{}


### PR DESCRIPTION
Creates the intended public API for the inject package. Nearly all of
the intended functionality is unimplemented at this point. The
intentions of publishing the non-functional API are to have a concrete
basis for discussion about the API's intention and implementation, and
to support leaning on the compiler to test the ergonomics of the API.